### PR TITLE
support rubyzip 1.3.0

### DIFF
--- a/axlsx.gemspec
+++ b/axlsx.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
   s.test_files  = Dir.glob("{test/**/*}")
 
   s.add_runtime_dependency 'nokogiri', '>= 1.4.1'
-  s.add_runtime_dependency 'rubyzip', '~> 1.2.1'
+  s.add_runtime_dependency 'rubyzip', '~> 1.3.0'
   s.add_runtime_dependency "htmlentities", "~> 4.3.1"
 
   s.add_development_dependency 'yard'


### PR DESCRIPTION
This is for fixing CVE-2019-16892.